### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-clh
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-dragonball
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-fc
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-qemu
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-runc.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-runc.yaml
@@ -15,7 +15,7 @@ spec:
         run: php-apache-runc
     spec:
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/versions.yaml
+++ b/versions.yaml
@@ -257,7 +257,7 @@ externals:
 
   pause:
     description: "Kubernetes pause container image"
-    repo: "docker://k8s.gcr.io/pause"
+    repo: "docker://registry.k8s.io/pause"
     version: "3.6"
 
   runc:


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780